### PR TITLE
Add alias support for select in SQL builder

### DIFF
--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -455,6 +455,13 @@ class Select extends AbstractPredicateClause
         // Else, if there is a nested SELECT statement.
         } else if ($this->table instanceof \Pop\Db\Sql\Select) {
             $sql .= (string)$this->table;
+        // Else, if there is an aliased table
+        } else if (is_array($this->table)) {
+            if (count($this->table) !== 1)
+                throw new Exception('Error: Only one table can be used in FROM clause.');
+            $alias = array_key_first($this->table);
+            $table = $this->table[$alias];
+            $sql .= $this->quoteId($table) . ' AS ' . $this->quoteId($alias);
         // Else, just select from the table
         } else {
             $sql .= $this->quoteId($this->table);

--- a/tests/Sql/SelectTest.php
+++ b/tests/Sql/SelectTest.php
@@ -37,6 +37,13 @@ class SelectTest extends TestCase
         $this->db->disconnect();
     }
 
+    public function testTableAlias()
+    {
+        $sql = $this->db->createSql();
+        $sql->select(['u.username'])->from(['u' => 'users']);
+        $this->assertEquals('SELECT `u`.`username` FROM `users` AS `u`', $sql->render());
+    }
+
     public function testJoin()
     {
         $sql = $this->db->createSql();


### PR DESCRIPTION
This adds table name aliasing capabilites to the `Select::from()` clause, using the same shorthand as in the various `Select::join()`. A simple test case is included.

This can be very useful for self-joins in tree-like structures, where otherwise columns would be ambiguous or require re-stating the table name very often. An example from my project, using the `Record` classes to avoid hard-coding table names:
```php
$q->select(['a.id'])
  ->from(['a' => Inodes::table()])
  ->leftJoin(['b' => Inodes::table()], ['b.id' => 'a.parent_id'])
  ...
```
Result (wrapped for readability):
```sql
SELECT "a"."id"
FROM "inodes" AS "a"
LEFT JOIN "inodes" AS "b" ON ("b"."id" = "a"."parent_id")
...
```

