### PR TITLE
Handle nested transactions as a single transaction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ vendor
 kettle
 .phpunit.result.cache
 .phpunit.cache
+test1.php
+test2.php
+test3.php
+test4.php
+app
+bootstrap.php


### PR DESCRIPTION
In case you call transactions from different places in your code under one other transaction, those end up being nested.

The idea is that there should ever only be one transaction ever - from a db point of view. In the code they might appear
to be multiple transactions, but that is not the case. 

Example:
```php
Record::transaction(function(){

	$role = new Role([

		"name"=>"test_role"
	]);
	$role->save();

	// throw new Exception("Fail 1!");
	Record::transaction(function(){

		$role = new Role([

			"name"=>"test_role1"
		]);
		$role->save();

		// throw new Exception("Fail 2!");

		$user = new User([

			"username"=>"yadmin",
			"password"=>sha1("p@55w0rd$$"),
			"role_id"=>$role->id
		]);
		$user->save();
	});

	$user = new User([

		"username"=>"xadmin",
		"password"=>sha1("p@55w0rd$$"),
		"role_id"=>$role->id
	]);
	$user->save();
});
```