### PR TITLE
Collected (mostly) doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,8 +1046,8 @@ $users = Users::execute($sql, ['last_login' => '2023-11-01 08:00:00']);
 Transactions are available through the ORM active record class. There are a few ways to
 execute a transaction with the main record class. In the below example, the transaction
 is started by calling the `startTransaction()` method. Once that has been called, the
-subsequent `commitTransaction()` will be called within the `save()` method. Or, the
-`rollback` method will be called upon an exception being thrown.
+subsequent `save()` will automatically call `commitTransaction()` on successful save or
+the `rollback` method will be called upon an exception being thrown.
 
 ```php
 $user = new Users([
@@ -1059,7 +1059,8 @@ $user->startTransaction();
 $user->save();
 ```
 
-A shorthand way of doing the same would be to call the static `start()` method:
+A shorthand way of doing the same would be to call the static `start()` method, which combines the
+constructor and `startTransaction` calls:
 
 ```php
 $user = Users::start([

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -194,7 +194,7 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
-     * Check is transaction is success
+     * Check if transaction is success
      *
      * @return bool
      */

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -104,7 +104,7 @@ interface AdapterInterface
     public function transaction(mixed $callable, mixed $params = null): void;
 
     /**
-     * Check is transaction is success
+     * Check if transaction is success
      *
      * @return bool
      */

--- a/src/Adapter/Mysql.php
+++ b/src/Adapter/Mysql.php
@@ -189,7 +189,7 @@ class Mysql extends AbstractAdapter
     }
 
     /**
-     * Check is transaction is success
+     * Check if transaction is success
      *
      * @return bool
      */

--- a/src/Adapter/Pdo.php
+++ b/src/Adapter/Pdo.php
@@ -234,7 +234,7 @@ class Pdo extends AbstractAdapter
     }
 
     /**
-     * Check is transaction is success
+     * Check if transaction is success
      *
      * @return bool
      */

--- a/src/Adapter/Pgsql.php
+++ b/src/Adapter/Pgsql.php
@@ -191,7 +191,7 @@ class Pgsql extends AbstractAdapter
     }
 
     /**
-     * Check is transaction is success
+     * Check if transaction is success
      *
      * @return bool
      */

--- a/src/Adapter/Sqlite.php
+++ b/src/Adapter/Sqlite.php
@@ -176,7 +176,7 @@ class Sqlite extends AbstractAdapter
     }
 
     /**
-     * Check is transaction is success
+     * Check if transaction is success
      *
      * @return bool
      */

--- a/src/Adapter/Sqlsrv.php
+++ b/src/Adapter/Sqlsrv.php
@@ -179,7 +179,7 @@ class Sqlsrv extends AbstractAdapter
     }
 
     /**
-     * Check is transaction is success
+     * Check if transaction is success
      *
      * @return bool
      */

--- a/src/Record.php
+++ b/src/Record.php
@@ -197,18 +197,19 @@ class Record extends Record\AbstractRecord
     }
 
     /**
-     * Start transaction with the DB adapter
+     * Start transaction with the DB adapter. When called on a descendent class, construct
+     * a new object and use it for transaction management.
      *
-     * @throws \ReflectionException|Exception
+     * @param mixed ...$constructorArgs Arguments passed to descendent class constructor
      * @return static|null
+     * @throws Exception|Record\Exception
      */
-    public static function start(): static|null
+    public static function start(mixed ...$constructorArgs): static|null
     {
-        $args  = func_get_args();
         $class = get_called_class();
 
-        if ($class !== 'Pop\Db\Record') {
-            $record = (!empty($args)) ? (new \ReflectionClass($class))->newInstanceArgs($args) : new static();
+        if ($class !== Record::class) {
+            $record = new static(...$constructorArgs);
             $record->startTransaction();
             return $record;
         } else {

--- a/src/Sql/Schema.php
+++ b/src/Sql/Schema.php
@@ -104,8 +104,7 @@ class Schema extends AbstractSql
      */
     public function dropIfExists(string $table): Schema\Drop
     {
-        $this->getDropTable($table)->ifExists();
-        return $this->getDropTable($table);
+        return $this->getDropTable($table)->ifExists();
     }
 
     /**

--- a/src/Sql/Schema/AbstractStructure.php
+++ b/src/Sql/Schema/AbstractStructure.php
@@ -299,12 +299,12 @@ abstract class AbstractStructure extends AbstractTable
     /**
      * Create an index
      *
-     * @param  string  $column
+     * @param  string|array $column
      * @param  ?string $name
-     * @param  string  $type
+     * @param  string $type
      * @return AbstractStructure
      */
-    public function index(string $column, ?string $name = null, string $type = 'index'): AbstractStructure
+    public function index(string|array $column, ?string $name = null, string $type = 'index'): AbstractStructure
     {
         if (!is_array($column)) {
             $column = [$column];
@@ -333,11 +333,11 @@ abstract class AbstractStructure extends AbstractTable
     /**
      * Create a UNIQUE index
      *
-     * @param  ?string $column
+     * @param  string|array|null $column
      * @param  ?string $name
      * @return AbstractStructure
      */
-    public function unique(?string $column = null, ?string $name = null): AbstractStructure
+    public function unique(string|array|null $column = null, ?string $name = null): AbstractStructure
     {
         if ($column === null) {
             $column = $this->currentColumn;
@@ -348,11 +348,11 @@ abstract class AbstractStructure extends AbstractTable
     /**
      * Create a PRIMARY KEY index
      *
-     * @param  ?string $column
+     * @param  string|array|null $column
      * @param  ?string $name
      * @return AbstractStructure
      */
-    public function primary(?string $column = null, ?string $name = null): AbstractStructure
+    public function primary(string|array|null $column = null, ?string $name = null): AbstractStructure
     {
         if ($column === null) {
             $column = $this->currentColumn;


### PR DESCRIPTION
Some smaller fixes that don't really warrant their own PRs. There are no true functional changes, only doc or interface declaration changes.

* fix the parameter type for the first parameter of schema index creation functions to correcly accept multi-column indices
* fix the instance returned by `Schema::dropIfExists` (this wasn't really broken as `getDropTable` returns the same instance, but this way it looks cleaner)
* Fix a typo in Adapter docstrings
* Improve the documentation for `Record::start()` after the discussion on #8
  I've also made it use a named rest parameter and spread syntax instead of `func_get_args` and reflection to get better docs and IDE support
