### PR TITLE
Improve parameter handling for PDO connections

### DIFF
--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -307,8 +307,15 @@ abstract class AbstractSql
 
         $this->incrementParameterCount();
 
-        if (($detectedDbType !== null) && ($this->dbType != $detectedDbType)) {
-            switch ($this->dbType) {
+        // If the parameter is given in a different format than what the db expects, translate it
+        $realDbType = $this->dbType;
+        if ($this->placeholder == ':') {
+            // Either native SQLITE or PDO, in which case also use :param syntax
+            $realDbType = self::SQLITE;
+        }
+
+        if (($detectedDbType !== null) && ($realDbType != $detectedDbType)) {
+            switch ($realDbType) {
                 case self::MYSQL:
                 case self::SQLSRV:
                     $parameter = '?';


### PR DESCRIPTION
PDO can deal with bind parameter names in `:param` (SQLITE) or `?` (MySql) syntax, where `:param` is preferred.

An issue arises when connecting with PDO to Postgres, which expects `$1` natively but must still use `:param` when used via PDO, as PDO does all the translating.

This adds a special case handling in `AbstractSQL::getParameter` to not double-translate the format to the target DB. Instead, the translation also takes the placeholder as inferred in `init()` into account.


Alternative implementation would have been to not look at `$this-dbType` at all and only go by the (auto-)configured placeholder, but I'm not sure if that would have some other implications?